### PR TITLE
Enable inserting code blocks in latex code

### DIFF
--- a/本科实验报告(模版).tex
+++ b/本科实验报告(模版).tex
@@ -17,7 +17,9 @@
 \usepackage{subfigure}
 \usepackage{tabularx}
 \usepackage{titlesec}
-  
+\usepackage{listings}
+\usepackage{fontspec}
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % 实验信息
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -46,6 +48,24 @@
 \setCJKsansfont{SimHei}
 \setCJKmonofont{SimSun}
 \punctstyle{kaiming}
+\setmonofont{Consolas}
+
+% 代码块样式
+\lstset{
+ columns=fixed,       
+ numbers=left,                                        % 在左侧显示行号
+ numberstyle=\tiny\color{gray},                       % 设定行号格式
+ frame=lines,                                          % 不显示背景边框
+%  backgroundcolor=\color[RGB]{245,245,244},            % 设定背景颜色
+ keywordstyle=\color[RGB]{40,40,255},                 % 设定关键字颜色
+ numberstyle=\footnotesize\color{darkgray},           
+ commentstyle=\color{red!50!green!50!blue!50},        % 设置代码注释的格式
+ stringstyle=\rmfamily\slshape\color[RGB]{128,0,0},   % 设置字符串格式
+ showstringspaces=false,                              % 不显示字符串中的空格
+ language=c++,                                        % 设置语言
+ basicstyle=\ttfamily,
+ breaklines=true
+}
 
 % 行间距
 \renewcommand{\baselinestretch}{1.0}

--- a/本科实验报告(模版).tex
+++ b/本科实验报告(模版).tex
@@ -19,6 +19,7 @@
 \usepackage{titlesec}
 \usepackage{listings}
 \usepackage{fontspec}
+\usepackage{xcolor}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % 实验信息
@@ -55,12 +56,12 @@
  columns=fixed,       
  numbers=left,                                        % 在左侧显示行号
  numberstyle=\tiny\color{gray},                       % 设定行号格式
- frame=lines,                                          % 不显示背景边框
-%  backgroundcolor=\color[RGB]{245,245,244},            % 设定背景颜色
+ frame=single,                                        % 设定背景边框
+ backgroundcolor=\color[RGB]{245,245,244},            % 设定背景颜色
  keywordstyle=\color[RGB]{40,40,255},                 % 设定关键字颜色
  numberstyle=\footnotesize\color{darkgray},           
  commentstyle=\color{red!50!green!50!blue!50},        % 设置代码注释的格式
- stringstyle=\rmfamily\slshape\color[RGB]{128,0,0},   % 设置字符串格式
+%  stringstyle=\rmfamily\slshape\color[RGB]{128,0,0},   % 设置字符串格式
  showstringspaces=false,                              % 不显示字符串中的空格
  language=c++,                                        % 设置语言
  basicstyle=\ttfamily,


### PR DESCRIPTION
在LaTeX代码中插入代码块，代码默认字体为 Consolas，能高亮部分关键字，能够个性化设置背景颜色。使用 code listing 实现(https://www.overleaf.com/learn/latex/Code_listing)